### PR TITLE
fix/battleReward/ItemData now is rewarded in correct inventory accord…

### DIFF
--- a/src/modules/battle/results/battleVictory.ts
+++ b/src/modules/battle/results/battleVictory.ts
@@ -59,8 +59,9 @@ export const battleVictory = async (
         monster.drops.items[
           Math.floor(Math.random() * monster.drops.items.length)
         ];
+
       const itemData = [...equippables, ...consumables, ...sellables].find(
-        (el) => (el.name = itemName)
+        (el) => el.name === itemName
       );
 
       if (!itemData) {


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Fix a bug related to item drop in wrong inventory when you defeat a monster in a battle. The problem occours when you defeat a monster and win an item reward, the item always goes to equippable inventory, now the item is pushed to the right inventory.

## Related Issue:

Closes #118 
