### PR TITLE
fix/battlereward/awarding gold on battle victory

### DIFF
--- a/src/modules/battle/results/battleVictory.ts
+++ b/src/modules/battle/results/battleVictory.ts
@@ -33,6 +33,7 @@ export const battleVictory = async (
     character.stats.health = health;
     character.stats.mana = mana;
     character.experience.xp = character.experience.xp + monster.drops.exp;
+    character.inventory.gold = character.inventory.gold + monster.drops.gold;
     if (
       character.experience.level < 100 &&
       character.experience.xp >= levelScale[character.experience.level]
@@ -76,7 +77,6 @@ export const battleVictory = async (
           resultString += `\nThe monster dropped a ${itemName}, but your backpack is too full!`;
         } else {
           character.inventory[itemData.type].push(itemData.name);
-          character.markModified("inventory");
           resultString += `\nThe monster dropped a ${itemName}! You slip it into your backpack.`;
         }
       }
@@ -84,6 +84,7 @@ export const battleVictory = async (
 
     character.markModified("stats");
     character.markModified("experience");
+    character.markModified("inventory");
     await character.save();
 
     const resultEmbed = new MessageEmbed();


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

<!--A brief description of what your pull request does.-->
Fix a bug where when the player wins a battle, the gold is not awarded

![image](https://user-images.githubusercontent.com/5982809/135905341-332b3684-7955-485d-9aae-0733cbf3c60c.png)

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #117 