### PR TITLE
feat: sort subcommands

### DIFF
--- a/src/utils/registerCommands.ts
+++ b/src/utils/registerCommands.ts
@@ -30,7 +30,11 @@ export const registerCommands = async (
       options?: APIApplicationCommandOption[];
     }[] = [];
 
-    Rosa.commands.forEach((command) => commandData.push(command.data.toJSON()));
+    Rosa.commands.forEach((command) => {
+      const data = command.data.toJSON();
+      data.options?.sort((a, b) => a.name.localeCompare(b.name));
+      commandData.push(data);
+    });
     if (process.env.NODE_ENV === "production") {
       rosaLogHandler.log("debug", "registering commands globally!");
       await rest.put(Routes.applicationCommands(Rosa.configs.userId), {


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Discord sorts commands in the UI alphabetically, but only for top level commands. This adds a step to sort the subcommands before registering, making things a bit easier to find.

<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
